### PR TITLE
JQL composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # python_elves
 Little helpers written in Python
+
+## JQL Composer
+The script is used to compose complex JQL queries from a JSON-encoded dictionary of simpler sub-queries.
+
+It will enclose the expansion of sub-queries in parentheses while expanding, in order to ensure the original precedence.
+
+In order to use one query inside another, use the sub-query's name in brackets inside the outer query. See sample.json for an example.

--- a/jqlcomposer/jqlcomposer.py
+++ b/jqlcomposer/jqlcomposer.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+import sys
+
+def err(msg, rv=1):
+  print(msg)
+  sys.exit(rv)
+
+def cut_next(query_text):
+  if query_text[0] == "{":
+    length = 1
+    while query_text[length] != "}":
+      length += 1
+    return True, query_text[1:length], query_text[length+1:]
+  
+  length = 1
+  while length < len(query_text) and query_text[length] != "{":
+    length += 1
+  return False, query_text[0:length], query_text[length:] if length < len(query_text) else ""
+
+def compose(json_struct, token):
+  if token not in json_struct:
+    err(f"No rule to compose {repr(token)}!")
+  outcome = []
+  base = json_struct[token]
+  while len(base) > 0:
+    translate, next, base = cut_next(base)
+    # print(f"Add {'translated ' if translate else ''} {repr(next)} and continue to parse {repr(base)}")
+    if translate:
+      outcome.append(f"({compose(json_struct, next)})")
+    else:
+      outcome.append(next)
+  return "".join(outcome)
+  
+def compose_from_file(filename, token):
+  with open(filename) as f:
+    return compose(json.load(f), token)
+
+def compose_from_string(json_text, token):
+  return compose(json.loads(json_text), token)
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+                    prog='jqlcomposer',
+                    description='Create a full JQL query from a JSON-encoded dictionary of tokens')
+  parser.add_argument("token")
+  parser.add_argument("input")
+  parser.add_argument("--filename", action="store_true")
+  settings = parser.parse_args()
+  if settings.filename:
+    print(compose_from_file(settings.input, settings.token))
+  else:
+    print(compose_from_string(settings.input, settings.token))
+ 

--- a/jqlcomposer/sample.json
+++ b/jqlcomposer/sample.json
@@ -1,0 +1,5 @@
+{
+"home": "{go_to} next {corner}",
+"go_to": "See you",
+"corner": "Saturday"
+}


### PR DESCRIPTION
In order to mitigate that JQL doesn't support sub-queries, I wrote a script that should make it easier to re-use queries inside one another.

From the addition to the readme:

The script is used to compose complex JQL queries from a JSON-encoded dictionary of simpler sub-queries.

It will enclose the expansion of sub-queries in parentheses while expanding, in order to ensure the original precedence.

In order to use one query inside another, use the sub-query's name in brackets inside the outer query. See sample.json for an example.